### PR TITLE
Implementar targets iniciales de Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+SHELL := /bin/bash
+PROJECT_NAME := analizador-cache
+OUT_DIR := out
+DIST_DIR := dist
+
+.PHONY: help tools test clean
+
+help: ## Muestra esta ayuda.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+tools: ## Verifica que las herramientas requeridas estén instaladas.
+	@echo "Verificando herramientas requeridas..."
+	@for tool in curl bats; do \
+		if ! command -v $$tool &> /dev/null; then \
+			echo "Error: '$$tool' no está instalado. Por favor, instálalo."; \
+			exit 1; \
+		fi \
+	done
+	@echo "Todas las herramientas están instaladas."
+
+test: ## Ejecuta la suite de pruebas con Bats.
+	@echo "Ejecutando pruebas..."
+	@bats tests/
+
+clean: ## Limpia los directorios de salida.
+	@echo "Limpiando directorios de salida..."
+	@rm -rf $(OUT_DIR) $(DIST_DIR)
+	@echo "Limpieza completada."


### PR DESCRIPTION
### ¿Qué se hizo?
Se ha creado la primera versión del `Makefile` con los targets básicos de automatización requeridos para el Sprint 1.

### ¿Por Qué se hizo?
Para establecer la base del flujo de trabajo automatizado del proyecto, cumpliendo con el principio de 12-Factor V (separación de etapas) y los requisitos de la práctica calificada. Esto permite a todo el equipo verificar su entorno, ejecutar pruebas y limpiar el proyecto de manera consistente.

### ¿Cómo se implementó?
- Se añadió un target `help` auto-documentado que lee los comentarios del propio archivo.
-  target `tools` utiliza un bucle y `command -v` para verificar la existencia de `curl` y `bats`. 
-Los targets `test` y `clean` ejecutan los comandos estándar de `bats` y `rm -rf` respectivamente.
- Todos los targets que no producen archivos se han declarado con `.PHONY`.