### PR TITLE
test: Añadir prueba fallida para recolección de headers (RED)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,5 @@
 # Proyecto 6: Analizador de Headers de Cache
+Documentación de variables:
+| Variable | Descripción                                                            | Ejemplo                                                |
+|:--------:|------------------------------------------------------------------------|--------------------------------------------------------|
+|$TARGETS  |Incluye las URLs las cuales se quieren consultar, separadas por espacios| TARGETS="www.google.com www.example.com www.github.com"|

--- a/docs/contrato-salidas.md
+++ b/docs/contrato-salidas.md
@@ -1,0 +1,5 @@
+## Estructura
+Estructura de archivo `headers.csv`
+```
+URL,Cache-Control,ETag,Expires
+```

--- a/tests/collect.bats
+++ b/tests/collect.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+OUT_DIR="out"
+OUT_HEADERS="$OUT_DIR/headers.csv"
+
+@test "Makefile: Correcta creación de $OUT_HEADERS" {
+    #echo "$OUT_DIR" >&3
+    #echo "$OUT_HEADERS" >&3
+    run make run
+    if [ ! -d "$OUT_DIR" ]; then
+        echo "no existe directorio $OUT_DIR" >&2
+        false
+    else
+        if [ ! -f "$OUT_HEADERS" ]; then
+            echo "no existe archivo $OUT_HEADERS" >&2
+            false
+        fi
+    fi
+    
+    echo "archivo $OUT_HEADERS existe" >&3
+    
+    if [ ! -s "$OUT_HEADERS" ]; then
+        echo "$OUT_HEADERS esta vacio" >&2
+        false
+    else
+        echo "$OUT_HEADERS no esta vacio" >&3
+    fi
+}


### PR DESCRIPTION
### Descripción
Se hizo la primera parte de pruebas, en la cual se creo un test el cual falla intencionalmente, esto para ser reparado por el siguiente integrante, tambien se definió el contrato el archivo .csv donde se van a guardar los headers para analisis. Por ultimo, se hizo una descripción de TARGETS, una variable en la cual se guardan las URLs a analizar.
### Evidencias
Ejecución del test fallido
<img width="913" height="259" alt="image" src="https://github.com/user-attachments/assets/97ad0335-a8b0-4118-8b54-3bf3f050da5e" />
### Checklist
- Se definió el contrato del archivo `out/headers.csv` (El como los headers se guardan en el archivo .csv) en  `docs/contrato-salidas.md`
- Se escribió un test que verifica si `out/headers.csv` se genera de forma correcta (el cual intencionalmente falla)
- Se documento la variable TARGETS en `docs/README.md`