### PR TITLE
Reparé el resultado de la matriz

### DIFF
--- a/docs/contrato-salidas.md
+++ b/docs/contrato-salidas.md
@@ -3,3 +3,6 @@ Estructura de archivo `headers.csv`
 ```
 URL,Cache-Control,ETag,Expires
 ```
+Ciertos valores se van a poner entre comillas porque podrían contener comas u otros caracteres especiales.
+
+**IMPORTANTE:** Los detalles de `Cache-Control` se separan por punto y coma ( `;` ) debido a un conflicto con las comas en el archivo CSV.

--- a/docs/targets.txt
+++ b/docs/targets.txt
@@ -2,3 +2,7 @@ https://www.google.com
 https://www.bing.com
 https://probando_link_que_no_exite.com
 https://www.example.com
+https://github.com
+https://fonts.googleapis.com/css?family=Roboto
+https://www.cloudflare.com
+https://soundcloud.com/

--- a/src/analizador.sh
+++ b/src/analizador.sh
@@ -41,6 +41,8 @@ recolectar() {
         ETAG=${ETAG:-N/A}
         EXPIRES=${EXPIRES:-N/A}
 
+        CACHE_CONTROL=$(echo "$CACHE_CONTROL" | sed 's/,/;/g')
+
         echo "\"${target}\",\"${CACHE_CONTROL}\",\"${ETAG}\",\"${EXPIRES}\"" >> "$OUT_HEADERS"
     done < "$TARGETS_FILE"
 


### PR DESCRIPTION
Los detalles de `Cache-Control` se separan por punto y coma ( `;` ) debido a un conflicto con las comas en el archivo CSV.
