### PR TITLE
docs: Finalizar README y contrato de salidas

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,9 @@
 Documentación de variables:
 | Variable | Descripción                                                            | Ejemplo                                                |
 |:--------:|------------------------------------------------------------------------|--------------------------------------------------------|
-|$TARGETS  |Incluye las URLs las cuales se quieren consultar, separadas por espacios| TARGETS="www.google.com www.example.com www.github.com"|
+|TARGETS  |Incluye las URLs las cuales se quieren consultar, separadas por saltos de linea en `docs/targets.txt`| `TARGETS="www.google.com\nwww.example.com\nwww.github.com"`|
+|MIN_MAX_AGE  | Establece un mínimo valor de `max-age` de la cabecera `Cache-Control` para el cumplimiento de la Regla 1 (Por defecto en 0). | `MIN_MAX_AGE=100`|
+|MIN_S_MAXAGE  | Establece un mínimo valor de `s-maxage` de la cabecera `Cache-Control` para el cumplimiento de la Regla 1 (Por defecto en 0). | `MIN_S_MAXAGE=9600`|
 
 ## Reglas de Cumplimiento de Cache
 

--- a/docs/bitacora-sprint-3.md
+++ b/docs/bitacora-sprint-3.md
@@ -33,3 +33,9 @@ El objetivo era optimizar el target `run` para que el script `analizador.sh` sol
   - **Síntoma**: Incluso después de corregir el error tipográfico, el comando `touch` seguía fallando. El script `analizador.sh` se ejecutaba, pero el directorio `out/` desaparecía antes de que se pudiera crear el archivo `.cache`.
   - **Causa Raíz**: El script `analizador.sh` contiene una función `cleanup` que se activa con `trap` y elimina el directorio `out/` al finalizar la ejecución. Este comportamiento se puede desactivar con una variable de entorno.
   - **Solución**: Se añadió la variable de entorno `ANALIZADOR_NO_CLEANUP=true` a la llamada del script en el `Makefile`. Esto evita la limpieza automática del directorio `out/` y permite que el archivo `.cache` se cree correctamente, completando la implementación de la caché.
+
+### Actualización del README.md, contrato-salidas.md y `make help`
+
+- La tabla de variable de entorno del documento `README.md` fue actualizada para incluir las dos variables añadidas para la configuración de Regla 1 (`MIN_MAX_AGE` y  `MIN_S_MAXAGE`).
+- `contrato-salidas.md` fue actualizado para especificar el formato de salida de la matriz en `matriz_cumplimiento.csv`, tambien se especifico la salida de las cabeceras en `headers.csv`
+- Se actualizaron los comentarios en el `Makefile` que incluyen descripciones de los targets. Estos son impresos en terminal via un `grep` en `make help`, junto a su respectivo target.


### PR DESCRIPTION
### Descripción
- Actualización de documentos `README.md`, `contrato-salidas.md` y `make help`, para incluir cambios hechos en este Sprint (variables de entorno para configuración de Reglas).
### Evidencias
Ejecución de `make help`
<img width="817" height="190" alt="image" src="https://github.com/user-attachments/assets/7a607248-3845-4016-870e-0e4e0cc3b21c" />
